### PR TITLE
fix: Change DeepSeeker model to Q4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We have published benchmarks for these models on https://leaderboard.tabbyml.com
 | [RiQuY/CodeLlama-13B](https://huggingface.co/codellama/CodeLlama-13b-hf) | [Llama 2](https://github.com/facebookresearch/llama/blob/main/LICENSE) |
 | [RiQuY/DeepseekCoder-1.3B](https://huggingface.co/deepseek-ai/deepseek-coder-1.3b-base) | [Deepseek License](https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL) |
 | [RiQuY/DeepseekCoder-6.7B](https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base) | [Deepseek License](https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL) |
-| [RiQuY/DeepseekCoder-6.7B-Q5_K_M](https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base) | [Deepseek License](https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL) |
+| [RiQuY/DeepseekCoder-6.7B-Q4_K_M](https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base) | [Deepseek License](https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL) |
 
 
 ## Chat models (`--chat-model`)

--- a/meta/models.yaml
+++ b/meta/models.yaml
@@ -100,10 +100,10 @@
   - https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-GGUF/resolve/main/deepseek-coder-6.7b-base.Q8_0.gguf
   sha256: a2f82242ac5e465037cbf1ed754f04f0be044ee196e1589905f9e4dcd0e6559d
 
-- name: DeepseekCoder-6.7B-Q5_K_M
+- name: DeepseekCoder-6.7B-Q4_K_M
   <<: *deepseek-series
   provider_url: https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base
 
   urls:
-  - https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-GGUF/resolve/main/deepseek-coder-6.7b-base.Q5_K_M.gguf
+  - https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-GGUF/resolve/main/deepseek-coder-6.7b-base.Q4_K_M.gguf
   sha256: de874d119b3a8e6e7d5ca066cc8e8c0038196c9b3524a50ed2c967a1bcb641b9

--- a/models.json
+++ b/models.json
@@ -125,13 +125,13 @@
     "sha256": "a2f82242ac5e465037cbf1ed754f04f0be044ee196e1589905f9e4dcd0e6559d"
   },
   {
-    "name": "DeepseekCoder-6.7B-Q5_K_M",
+    "name": "DeepseekCoder-6.7B-Q4_K_M",
     "license_name": "Deepseek License",
     "license_url": "https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL",
     "prompt_template": "<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>",
     "provider_url": "https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base",
     "urls": [
-      "https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-GGUF/resolve/main/deepseek-coder-6.7b-base.Q5_K_M.gguf"
+      "https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-GGUF/resolve/main/deepseek-coder-6.7b-base.Q4_K_M.gguf"
     ],
     "sha256": "de874d119b3a8e6e7d5ca066cc8e8c0038196c9b3524a50ed2c967a1bcb641b9"
   }


### PR DESCRIPTION
[fix: Change DeepSeeker model to Q4](https://github.com/RiQuY/registry-tabby/commit/ef0047fda4d77972417ef97dd30f3185d9b41887)